### PR TITLE
Removed small typos from first chapters in React unit.

### DIFF
--- a/book-3-nashville-kennels/chapters/PROPS_STATE_INTRO.md
+++ b/book-3-nashville-kennels/chapters/PROPS_STATE_INTRO.md
@@ -8,7 +8,7 @@ Pass your name into a component and display it.
 
 > PropsAndState.js
 ```js
-import React, from "react"
+import React from "react"
 
 export const PropsAndState = ({ yourName }) => {
 
@@ -45,7 +45,7 @@ Display this component from the *Kennel* component and pass in your name. Don't 
 
 #### Goal: Display how many times a button has been clicked.
 
-Within the **StateAndProps** component, we will define state and a function to update state with the `useState` hook. We will also create a function `to handleClick`.
+Within the **StateAndProps** component, we will define state and a function to update state with the `useState` hook. We will also create a function `handleClick` to record state when clicked.
 
 > PropsAndState.js - updated
 ```js

--- a/book-3-nashville-kennels/chapters/REACT_BASICS.md
+++ b/book-3-nashville-kennels/chapters/REACT_BASICS.md
@@ -136,6 +136,7 @@ Update your **`Kennel`** component with the code provided below. Be sure to impo
 
 ```jsx
 import React from "react"
+import "./Kennel.css"
 import { AnimalCard } from "./animal/AnimalCard"
 import "./animal/Animal.css"
 
@@ -143,7 +144,6 @@ export const Kennel = () => (
     <>
         <h2>Nashville Kennels</h2>
         <small>Loving care when you're not there.</small>
-
         <address>
             <div>Visit Us at the Nashville North Location</div>
             <div>500 Puppy Way</div>
@@ -228,7 +228,7 @@ address {
 
 ## Practice
 
-The Nashville Kennel application needs to include locations, owners, and employees. Create static card components for each (`Location.js`, `Customer.js` and `Employee.js`) and a corresponding CSS file.
+The Nashville Kennel application needs to include locations, owners, and employees. Create static card components for each (`LocationCard.js`, `CustomerCard.js` and `EmployeeCard.js`) and a corresponding CSS file.
 
 Remember the Single Responsibility Principle. You should have a component whose sole responsibility is to render the location, or customer, or employee information. Make sure you create a different sub-directory for each kind of resource.
 


### PR DESCRIPTION
In REACT_BASICS.md: Added "import "./Kennel.css"" to the child component instructions. It was the only line excluded in the updated instructions and could be easily removed if the student pastes over all their previous code with the updated example.

Removed a line space in that component to be more consistent with earlier examples formatting.

Changed names of location, customer, and employee component JS files in final practice to match the animal component example file names earlier.

In PROPS_STATE_INTRO.md: Removed errant "," and moved the word "to" outside of the syntax highlighting for the function name.