### PR TITLE
Fix typo from 'same' to 'name'

### DIFF
--- a/book-3-nashville-kennels/chapters/JSON_SERVER_HEROKU.md
+++ b/book-3-nashville-kennels/chapters/JSON_SERVER_HEROKU.md
@@ -93,7 +93,7 @@ You can straight up copy pasta this into a `package.json` file in your API repo.
 
 ## Example server.js
 
-Here's a sample `server.js` file that you can put in your API repo.  Replace `yak.json` below with the same of your JSON file.
+Here's a sample `server.js` file that you can put in your API repo.  Replace `yak.json` below with the name of your JSON file.
 
 ```js
 const jsonServer = require('json-server');


### PR DESCRIPTION
I noticed a super minor typo in the JSON_SERVER instructions. Here's a super minor fix for it.